### PR TITLE
Ingress class name support

### DIFF
--- a/heimdall2/templates/ingress.yaml
+++ b/heimdall2/templates/ingress.yaml
@@ -17,6 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
 {{- if .Values.heimdall.ingress.tls }}
   tls:
   {{- range .Values.heimdall.ingress.tls }}

--- a/heimdall2/templates/ingress.yaml
+++ b/heimdall2/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
   {{- end }}
 spec:
 {{- if and .Values.heimdall.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.heimdall.className }}
+  ingressClassName: {{ .Values.heimdall.ingress.className }}
 {{- end }}
 {{- if .Values.heimdall.ingress.tls }}
   tls:

--- a/heimdall2/templates/ingress.yaml
+++ b/heimdall2/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
   {{- end }}
 spec:
 {{- if and .Values.heimdall.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.heimdall.className }}
 {{- end }}
 {{- if .Values.heimdall.ingress.tls }}
   tls:

--- a/heimdall2/templates/ingress.yaml
+++ b/heimdall2/templates/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if and .Values.heimdall.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
 {{- if .Values.heimdall.ingress.tls }}

--- a/heimdall2/values.yaml
+++ b/heimdall2/values.yaml
@@ -81,6 +81,7 @@ heimdall:
      traefik.ingress.kubernetes.io/router.entrypoints: websecure
      traefik.ingress.kubernetes.io/router.tls: "true"
      traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+    #className:
     hosts:
       - host: heimdall-test.sandbox.c2il.org
         paths:


### PR DESCRIPTION
Without the "ingressClassName" property, this is the default Ingress Class defined in Kubernetes that is used. However, it could be have several ingress in infrastructure. So the helm chart should support this property.
The current MR add this property if it is in the purposed values and if the target kubernetes supports it.

Resources:
- Kubernetes ingress class : https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class