### PR TITLE
Make chart releaser point at correct dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
           echo "${{ github.workspace }}"
           pwd
           ls -lah
+          git diff --find-renames --name-only "heimdall-2.6.41" -- "${{ github.workspace }}"
+          git diff --find-renames --name-only "heimdall-2.6.41" -- "${{ github.workspace }}/heimdall2"
+          git diff --find-renames --name-only "heimdall-2.6.41" -- "heimdall2"
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,25 +26,13 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         uses: azure/setup-helm@v3
 
-      - name: debugging
+      - name: Change directories to where the charts are defined so the action can find the changed files properly
         run: |
-          echo "${{ github.workspace }}"
-          pwd
-          ls -lah
-          echo '1'
-          git diff --find-renames --name-only "heimdall-2.6.41" -- "${{ github.workspace }}"
-          echo '2'
-          git diff --find-renames --name-only "heimdall-2.6.41" -- "${{ github.workspace }}/heimdall2"
-          echo '3'
-          git diff --find-renames --name-only "heimdall-2.6.41" -- "heimdall2"
-          echo '4'
           cd heimdall2
-          git diff --find-renames --name-only "heimdall-2.6.41" -- "."
-          tr "/" "\n" <<<"." | sed '/^\(\.\)*$/d' | wc -l
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.6.0
         with:
-          charts_dir: "${{ github.workspace }}/heimdall2"
+          charts_dir: "."
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release Charts
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         with:
-          charts_dir: "${{ github.workspace }}"
+          charts_dir: "${{ github.workspace }}/heimdall2"
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,11 @@ jobs:
           echo "${{ github.workspace }}"
           pwd
           ls -lah
+          echo '1'
           git diff --find-renames --name-only "heimdall-2.6.41" -- "${{ github.workspace }}"
+          echo '2'
           git diff --find-renames --name-only "heimdall-2.6.41" -- "${{ github.workspace }}/heimdall2"
+          echo '3'
           git diff --find-renames --name-only "heimdall-2.6.41" -- "heimdall2"
 
       - name: Run chart-releaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,12 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         uses: azure/setup-helm@v3
 
+      - name: debugging
+        run: |
+          echo "${{ github.workspace }}"
+          pwd
+          ls -lah
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
           git diff --find-renames --name-only "heimdall-2.6.41" -- "${{ github.workspace }}/heimdall2"
           echo '3'
           git diff --find-renames --name-only "heimdall-2.6.41" -- "heimdall2"
+          echo '4'
+          cd heimdall2
+          git diff --find-renames --name-only "heimdall-2.6.41" -- "."
+          tr "/" "\n" <<<"." | sed '/^\(\.\)*$/d' | wc -l
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0


### PR DESCRIPTION
Root problem: release action was not working properly since it wasn't able to find the changed charts.
Details: The action goes through a relatively involved process to automatically find the set of directories where changes occurred which is dependent on the supplied variable, the working directory, and the git diff.  After finding those directories, it tries to find the charts.yaml file and see if the regen'd chart changed.  With the way we had things configured before, it was basically looking one level too deep and consequently not finding the charts.yaml file.
Resolution: Fixed configuration and setup so that the finding algorithm being used would identify changed directories at the appropriate level.