### PR TITLE
Add Tenable Hosting Variables to Helmchart

### DIFF
--- a/heimdall2/templates/heimdall-statefulset.yaml
+++ b/heimdall2/templates/heimdall-statefulset.yaml
@@ -204,6 +204,10 @@ spec:
             - name: TENABLE_HOST_URL
               value: {{ .Values.tenableHostUrl | quote }}
             {{- end }}
+            {{- if .Values.forceTenableFrontend }}
+            - name: FORCE_TENABLE_FRONTEND
+              value: {{ .Values.forceTenableFrontend | quote }}
+            {{- end }}
             {{- if .Values.githubClientId }}
             - name: GITHUB_CLIENTID
               valueFrom:

--- a/heimdall2/values.yaml
+++ b/heimdall2/values.yaml
@@ -46,6 +46,7 @@ databaseUsername: postgres
 
 # splunkHostUrl: default empty string (ex. https://your.splunk.domain.com)
 # tenableHostUrl: default empty string (ex. https://your.tenable.domain.com)
+# forceTenableFrontend: default false (If true, the frontend will use Tenable.SC Lite features
 
 # ldapEnabled: default false
 # ldapHost: url  # Must be set if using LDAP 


### PR DESCRIPTION
Update the Helmchart to include new environment variables that specify how the Tenable instance is hosted.