### PR TITLE
respect user supplied filename instead of forcing them to use certs.pem when certificates is enabled but the system certs approach is disabled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,26 @@
+# 3.3.4
+Updated license
+Repo was renamed to heimdall-helm and corresponding documentation updates
+Make stateful set respect the filename provided by the user when they have certificates enabled but the system certs approach disabled
+
+# 3.3.3
+Updated default postgres version to 17
+
+# 3.3.2
+Added support for the OIDC_USES_VERIFIED_EMAIL envvar
+
+# 3.3.1
+Updated license
+
+# 3.3.0
+Reworked certificates support
+
+# 3.2.1
+Minor fixes to the gateway functionality
+
+# 3.2.0
+Add SOPS secret support
+
 # 3.1.10
 Add external interfaces variables, specifically variables for splunk and tenable urls @georgedias
 

--- a/heimdall2/Chart.yaml
+++ b/heimdall2/Chart.yaml
@@ -3,7 +3,7 @@ name: heimdall
 description: Heimdall is a security results visualization tool that lets you view, store, and compare security scan results.
 
 type: application
-version: 3.3.3
+version: 3.3.4
 appVersion: "release-latest"
 
 annotations:

--- a/heimdall2/templates/heimdall-statefulset.yaml
+++ b/heimdall2/templates/heimdall-statefulset.yaml
@@ -93,9 +93,9 @@ spec:
           env:
             {{- if and (not .Values.certs.systemCertsApproach.enabled) .Values.certs.enabled }}          
             - name: NODE_EXTRA_CA_CERTS
-              value: /home/node/certs/certs.pem
+              value: /home/node/certs/{{ (index .Values.certs.certificates 0).filename }}
             - name: SSL_CERT_FILE
-              value: /home/node/certs/certs.pem
+              value: /home/node/certs/{{ (index .Values.certs.certificates 0).filename }}
             {{- end }}
             - name: NODE_ENV
               value: {{ .Values.nodeEnv | quote }}


### PR DESCRIPTION
Resolves #33 